### PR TITLE
Add search, login, and rating features

### DIFF
--- a/src/app/api/equipment/[id]/route.ts
+++ b/src/app/api/equipment/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import equipmentData from '@/data/equipment.json'
+import fs from 'fs/promises'
+import path from 'path'
 
 export async function GET(
   request: Request,
@@ -18,5 +20,40 @@ export async function GET(
   } catch (error) {
     console.error('Error fetching equipment:', error)
     return NextResponse.json({ error: 'Failed to fetch equipment' }, { status: 500 })
+  }
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const body = await request.json()
+    const { rating, comment } = body
+
+    const equipment = equipmentData.find(item => item.id === id)
+    if (!equipment) {
+      return NextResponse.json({ error: 'Equipment not found' }, { status: 404 })
+    }
+
+    const newReview = {
+      id: Date.now().toString(),
+      rating: Number(rating),
+      comment: comment ?? null,
+      createdAt: new Date().toISOString(),
+    }
+    equipment.reviews.push(newReview)
+    equipment.avgRating =
+      equipment.reviews.reduce((sum, r) => sum + r.rating, 0) /
+      equipment.reviews.length
+
+    const filePath = path.join(process.cwd(), 'src/data/equipment.json')
+    await fs.writeFile(filePath, JSON.stringify(equipmentData, null, 2), 'utf-8')
+
+    return NextResponse.json(equipment)
+  } catch (error) {
+    console.error('Error saving review:', error)
+    return NextResponse.json({ error: 'Failed to save review' }, { status: 500 })
   }
 }

--- a/src/app/api/equipment/route.ts
+++ b/src/app/api/equipment/route.ts
@@ -36,6 +36,6 @@ export async function GET(request: Request) {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST() {
   return NextResponse.json({ error: 'POST not implemented' }, { status: 501 })
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { AuthProvider } from '@/components/AuthContext'
+import { NavBar } from '@/components/NavBar'
 
 export const metadata: Metadata = {
   title: '卓球用具レビュー',
@@ -14,27 +16,14 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
-        <div className="min-h-screen bg-gray-100">
-          <nav className="bg-white shadow-lg">
-            <div className="max-w-7xl mx-auto px-4">
-              <div className="flex justify-between h-16">
-                <div className="flex">
-                  <a href="/" className="flex items-center">
-                    <span className="text-xl font-bold text-gray-800">卓球用具レビュー</span>
-                  </a>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <a href="/equipment" className="text-gray-600 hover:text-gray-900">
-                    用具一覧
-                  </a>
-                </div>
-              </div>
-            </div>
-          </nav>
-          <main className="flex-grow">
-            {children}
-          </main>
-        </div>
+        <AuthProvider>
+          <div className="min-h-screen bg-gray-100">
+            <NavBar />
+            <main className="flex-grow">
+              {children}
+            </main>
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/AuthContext';
+
+export default function LoginPage() {
+  const [name, setName] = useState('');
+  const { login } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name) return;
+    login(name);
+    router.push('/');
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">ログイン</h1>
+      <form onSubmit={handleSubmit} className="max-w-sm space-y-4">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="ユーザー名"
+          className="w-full border rounded px-3 py-2"
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          ログイン
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,56 @@
-import equipmentData from '@/data/equipment.json'
+"use client";
+import { useState } from 'react';
+import Link from 'next/link';
+import equipmentData from '@/data/equipment.json';
+import { StarRating } from '@/components/ui/StarRating';
 
 export default function Home() {
+  const [query, setQuery] = useState('');
+
+  const filtered = equipmentData
+    .filter(
+      (item) =>
+        item.name.toLowerCase().includes(query.toLowerCase()) ||
+        item.manufacturer.toLowerCase().includes(query.toLowerCase())
+    )
+    .sort((a, b) => b.avgRating - a.avgRating);
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold text-center mb-8">卓球用具一覧</h1>
-      
+
+      <div className="mb-6 flex justify-center">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="用具名やメーカーで検索"
+          className="w-full max-w-md border rounded px-3 py-2"
+        />
+      </div>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {equipmentData.map((item) => (
-          <div key={item.id} className="bg-white p-6 rounded-lg shadow-md">
-            <h2 className="text-xl font-semibold mb-2">{item.name}</h2>
-            <p className="text-gray-600 mb-2">{item.manufacturer}</p>
-            <p className="text-lg font-bold text-blue-600 mb-2">¥{item.price.toLocaleString()}</p>
-            <div className="flex items-center mb-4">
-              <div className="flex">
-                {[...Array(5)].map((_, i) => (
-                  <span
-                    key={i}
-                    className={`text-lg ${
-                      i < item.avgRating ? 'text-yellow-400' : 'text-gray-300'
-                    }`}
-                  >
-                    ★
-                  </span>
-                ))}
+        {filtered.map((item) => (
+          <Link key={item.id} href={`/equipment/${item.id}`} className="block">
+            <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition">
+              <h2 className="text-xl font-semibold mb-2">{item.name}</h2>
+              <p className="text-gray-600 mb-2">{item.manufacturer}</p>
+              <p className="text-lg font-bold text-blue-600 mb-2">¥{item.price.toLocaleString()}</p>
+              <div className="flex items-center mb-4">
+                <StarRating rating={item.avgRating} />
+                <span className="ml-2 text-gray-600">({item.avgRating})</span>
               </div>
-              <span className="ml-2 text-gray-600">({item.avgRating})</span>
+              <span className="bg-gray-100 text-gray-600 px-2 py-1 rounded text-sm">
+                {item.type === 'RUBBER'
+                  ? 'ラバー'
+                  : item.type === 'BLADE'
+                  ? 'ラケット'
+                  : item.type === 'BALL'
+                  ? 'ボール'
+                  : item.type}
+              </span>
             </div>
-            <span className="bg-gray-100 text-gray-600 px-2 py-1 rounded text-sm">
-              {item.type === 'RUBBER' ? 'ラバー' : 
-               item.type === 'BLADE' ? 'ラケット' : 
-               item.type === 'BALL' ? 'ボール' : item.type}
-            </span>
-          </div>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/components/AuthContext.tsx
+++ b/src/components/AuthContext.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { createContext, useContext, useState, useEffect } from 'react';
+
+type AuthContextType = {
+  user: string | null;
+  login: (name: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) setUser(stored);
+  }, []);
+
+  const login = (name: string) => {
+    setUser(name);
+    localStorage.setItem('user', name);
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+}
+

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,35 @@
+'use client';
+import Link from 'next/link';
+import { useAuth } from './AuthContext';
+
+export function NavBar() {
+  const { user, logout } = useAuth();
+
+  return (
+    <nav className="bg-white shadow-lg">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex justify-between h-16">
+          <div className="flex">
+            <Link href="/" className="flex items-center">
+              <span className="text-xl font-bold text-gray-800">卓球用具レビュー</span>
+            </Link>
+          </div>
+          <div className="flex items-center space-x-4">
+            <Link href="/equipment" className="text-gray-600 hover:text-gray-900">
+              用具一覧
+            </Link>
+            {user ? (
+              <>
+                <span className="text-gray-600">こんにちは、{user}</span>
+                <button onClick={logout} className="text-gray-600 hover:text-gray-900">ログアウト</button>
+              </>
+            ) : (
+              <Link href="/login" className="text-gray-600 hover:text-gray-900">ログイン</Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}
+

--- a/src/components/ui/StarRating.tsx
+++ b/src/components/ui/StarRating.tsx
@@ -1,20 +1,24 @@
 type StarRatingProps = {
   rating: number;
   maxStars?: number;
+  editable?: boolean;
+  onRate?: (rating: number) => void;
 };
 
-export function StarRating({ rating, maxStars = 5 }: StarRatingProps) {
+export function StarRating({ rating, maxStars = 5, editable = false, onRate }: StarRatingProps) {
   return (
     <div className="flex">
       {[...Array(maxStars)].map((_, i) => (
-        <span
+        <button
+          type="button"
           key={i}
-          className={`text-lg ${
-            i < rating ? 'text-yellow-400' : 'text-gray-300'
+          onClick={editable ? () => onRate?.(i + 1) : undefined}
+          className={`text-lg ${i < rating ? 'text-yellow-400' : 'text-gray-300'} ${
+            editable ? 'cursor-pointer' : ''
           }`}
         >
           ★
-        </span>
+        </button>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- Allow searching equipment on home page with results sorted by rating
- Introduce simple login system and navigation updates
- Enable logged-in users to submit ratings stored via API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68922ae2a50083208e94f2300bac4852