### PR TITLE
Add AuthProvider and NavBar components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import './globals.css'
+import { AuthProvider } from '@/components/AuthProvider'
+import { NavBar } from '@/components/NavBar'
 
 export const metadata: Metadata = {
   title: '卓球用具レビュー',
@@ -15,27 +16,14 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
-        <div className="min-h-screen bg-gray-100">
-          <nav className="bg-white shadow-lg">
-            <div className="max-w-7xl mx-auto px-4">
-              <div className="flex justify-between h-16">
-                <div className="flex">
-                  <Link href="/" className="flex items-center">
-                    <span className="text-xl font-bold text-gray-800">卓球用具レビュー</span>
-                  </Link>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <Link href="/equipment" className="text-gray-600 hover:text-gray-900">
-                    用具一覧
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </nav>
-          <main className="flex-grow">
-            {children}
-          </main>
-        </div>
+        <AuthProvider>
+          <div className="min-h-screen bg-gray-100">
+            <NavBar />
+            <main className="flex-grow">
+              {children}
+            </main>
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+type AuthContextType = {
+  user: string | null;
+  login: (name: string) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(null);
+
+  const login = (name: string) => setUser(name);
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuth } from './AuthProvider';
+
+export function NavBar() {
+  const { user } = useAuth();
+
+  return (
+    <nav className="bg-white shadow-lg">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex justify-between h-16">
+          <div className="flex">
+            <Link href="/" className="flex items-center">
+              <span className="text-xl font-bold text-gray-800">卓球用具レビュー</span>
+            </Link>
+          </div>
+          <div className="flex items-center space-x-4">
+            <Link href="/equipment" className="text-gray-600 hover:text-gray-900">
+              用具一覧
+            </Link>
+            {user && <span className="text-gray-600">こんにちは、{user}さん</span>}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create AuthProvider to supply authentication context
- extract navigation into NavBar component and wrap layout with provider

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6892a1aab0d08320ab3840ebf51879cd